### PR TITLE
Implement internationalization through vue-i18n

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -3,6 +3,9 @@ FROM node:22.16.0-alpine
 # Add git.
 RUN apk add --no-cache git
 
+# Add python because of the i18n-check script
+RUN apk add python3
+
 # Set the working directory in the container.
 WORKDIR /app
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM node:22.16.0-alpine
 
+# Add git.
+RUN apk add --no-cache git
+
 # Set the working directory in the container.
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,5 +1,8 @@
 FROM node:22.16.0-alpine AS builder
 
+# Add git.
+RUN apk add --no-cache git
+
 # Set the working directory in the container.
 WORKDIR /app
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -87,7 +87,7 @@ npm run i18n-extract
 This tool adds missing keys with an initial empty string as values. (A newer version of `vue-i18n-extract` includes
 an option to use `null` as initial value instead, but there is no release for this yet as of July 2025.)
 
-To check whether all keys are available **and** all messages have been translated, run:
+To check whether there are no missing keys **and** all messages have been translated, run:
 
 ```bash
 npm run i18n-check

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -73,3 +73,22 @@ bun run preview
 ```
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+
+## Internationalization
+
+Internationalization is implemented using the `vue-i18n` package. The message files are in the `locales` subdirectory.
+
+To extract new messages from the source code, run the `vue-i18n-extract` tool:
+
+```bash
+npm run i18n-extract
+```
+
+This tool adds missing keys with an initial empty string as values. (A newer version of `vue-i18n-extract` includes
+an option to use `null` as initial value instead, but there is no release for this yet as of July 2025.)
+
+To check whether all keys are available **and** all messages have been translated, run:
+
+```bash
+npm run i18n-check
+```

--- a/frontend/components/layout/NavBar.vue
+++ b/frontend/components/layout/NavBar.vue
@@ -11,7 +11,7 @@ import { BSIcon } from "cdh-vue-lib";
         <div class="uu-navbar-container">
             <div class="navbar-brand">
                 <img
-                    alt="Utrecht University"
+                    :alt="$t('Utrecht University')"
                     :src="useStaticFile('/images/logo-header-nl.svg')"
                 />
             </div>
@@ -38,7 +38,7 @@ import { BSIcon } from "cdh-vue-lib";
                             class="nav-link"
                             active-class="active"
                         >
-                            My studies
+                            {{ $t("My studies") }}
                         </NuxtLink>
                     </li>
                 </ul>

--- a/frontend/components/layout/PageFooter.vue
+++ b/frontend/components/layout/PageFooter.vue
@@ -2,7 +2,7 @@
     <footer class="uu-footer">
         <div class="col-12 col-md-4">
             <img
-                alt="Utrecht University"
+                :alt="$t('Utrecht University')"
                 :src="
                     useStaticFile(
                         '/images/logo-footer-nl.svg'
@@ -14,7 +14,7 @@
             <p>
                 MyResearch
                 <br />
-                Faculty of Humanities
+                {{ $t("Faculty of Humanities") }}
             </p>
         </div>
     </footer>

--- a/frontend/components/layout/PageHeader.vue
+++ b/frontend/components/layout/PageHeader.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { BSIcon } from "cdh-vue-lib";
+import {useI18n} from "vue-i18n";
+
 const title = useAppConfig().globalTitle;
+const i18n = useI18n();
+
+function setLocale(locale: string) {
+    i18n.locale.value = locale;
+    localStorage.locale = locale;
+}
 </script>
 
 <template>
@@ -8,7 +16,7 @@ const title = useAppConfig().globalTitle;
         <div class="uu-header-row">
             <div class="col-3">
                 <img
-                    alt="Utrecht University"
+                    :alt="$t('Utrecht University')"
                     :src="useStaticFile('/images/logo-header-nl.svg')"
                     class="uu-logo"
                 />
@@ -28,21 +36,23 @@ const title = useAppConfig().globalTitle;
                 </NuxtLink>
             </div>
             <div
-                v-if="false"
+                v-if="$i18n.locale === 'nl'"
                 class="language-switcher"
+                @click="setLocale('en')"
             >
                 English
             </div>
             <div
-                v-if="true"
+                v-if="$i18n.locale === 'en'"
                 class="language-switcher"
+                @click="setLocale('nl')"
             >
-                Dutch
+                Nederlands
             </div>
         </div>
         <div class="uu-header-row">
             <div class="ms-auto">
-                Not logged in
+                {{ $t("Not logged in") }}
             </div>
         </div>
     </div>

--- a/frontend/i18n-check.py
+++ b/frontend/i18n-check.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+import json
+import subprocess
+from pathlib import Path
+
+translation_path = Path(__file__).parent / "locales"
+translation_files = translation_path.glob("*.json")
+
+
+def check_empty_value(dictionary: dict) -> bool:
+    for (key, value) in dictionary.items():
+        if value == "":
+            print(f"Translation for '{key}' is missing.")
+            return True
+        if isinstance(value, dict) and check_empty_value(value):
+            return True
+    return False
+
+
+# First check for missing translation keys
+print("Checking for missing translation keys...")
+results = subprocess.run(
+    "npx vue-i18n-extract report --vueFiles './{components,pages,layouts,composables}/**/*.?(ts|vue)' --languageFiles './locales/*.?(json|yml|yaml|js)'",
+    shell=True,
+    check=True,
+    capture_output=True,
+)
+if "Missing Keys" in results.stdout.decode():
+    print("Missing translation keys found. Run 'npm run i18n-extract' and add the missing translations.")
+    exit(1)
+print("Ok.")
+
+for translation_file in translation_files:
+    print(f"Checking '{translation_file}' for missing translations...")
+    translations = json.load(open(translation_file, 'r'))
+    if check_empty_value(translations):
+        print("One or more translations are missing.")
+        exit(1)
+    print("Ok.")

--- a/frontend/i18n-check.py
+++ b/frontend/i18n-check.py
@@ -20,7 +20,7 @@ def check_empty_value(dictionary: dict) -> bool:
 # First check for missing translation keys
 print("Checking for missing translation keys...")
 results = subprocess.run(
-    "npx vue-i18n-extract report --vueFiles './{components,pages,layouts,composables}/**/*.?(ts|vue)' --languageFiles './locales/*.?(json|yml|yaml|js)'",
+    'npx vue-i18n-extract report --vueFiles "./{components,pages,layouts,composables}/**/*.{ts,vue}" --languageFiles "./locales/**/*.{json,yml,yaml,js}"',
     shell=True,
     check=True,
     capture_output=True,

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -5,7 +5,7 @@ const title = useAppConfig().globalTitle;
 <template>
     <div class="uu-root-container">
         <Head>
-            <Title>{{ title }}</Title>
+            <Title>MyResearch</Title>
         </Head>
         <LayoutPageHeader />
         <LayoutNavBar />

--- a/frontend/locales/nl.json
+++ b/frontend/locales/nl.json
@@ -1,0 +1,9 @@
+{
+  "Welcome to MyResearch!": "Welkom bij MyResearch!",
+  "Utrecht University": "Universiteit Utrecht",
+  "My studies": "Mijn studies",
+  "Faculty of Humanities": "Faculteit der Geesteswetenschappen",
+  "Not logged in": "Niet ingelogd",
+  "MyResearch": "MyResearch",
+  "Welcome!": "Welkom!"
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "nuxt": "^3.17.5",
         "uu-bootstrap": "git+https://github.com/UtrechtUniversity/UU-Bootstrap.git#v1.5.0-alpha.1",
         "vue": "^3.5.16",
+        "vue-i18n": "^11.1.9",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
@@ -1078,12 +1079,12 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.14.4",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.4.tgz",
-      "integrity": "sha512-vtZCt7NqWhKEtHa3SD/322DlgP5uR9MqWxnE0y8Q0tjDs9H5Lxhss+b5wv8rmuXRoHKLESNgw9d+EN9ybBbj9g==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.1.9.tgz",
+      "integrity": "sha512-Lrdi4wp3XnGhWmB/mMD/XtfGUw1Jt+PGpZI/M63X1ZqhTDjNHRVCs/i8vv8U1cwaj1A9fb0bkCQHLSL0SK+pIQ==",
       "dependencies": {
-        "@intlify/message-compiler": "9.14.4",
-        "@intlify/shared": "9.14.4"
+        "@intlify/message-compiler": "11.1.9",
+        "@intlify/shared": "11.1.9"
       },
       "engines": {
         "node": ">= 16"
@@ -1093,11 +1094,11 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.14.4",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.4.tgz",
-      "integrity": "sha512-vcyCLiVRN628U38c3PbahrhbbXrckrM9zpy0KZVlDk2Z0OnGwv8uQNNXP3twwGtfLsCf4gu3ci6FMIZnPaqZsw==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.1.9.tgz",
+      "integrity": "sha512-84SNs3Ikjg0rD1bOuchzb3iK1vR2/8nxrkyccIl5DjFTeMzE/Fxv6X+A7RN5ZXjEWelc1p5D4kHA6HEOhlKL5Q==",
       "dependencies": {
-        "@intlify/shared": "9.14.4",
+        "@intlify/shared": "11.1.9",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -1108,9 +1109,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.14.4",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.4.tgz",
-      "integrity": "sha512-P9zv6i1WvMc9qDBWvIgKkymjY2ptIiQ065PjDv7z7fDqH3J/HBRBN5IoiR46r/ujRcU7hCuSIZWvCAFCyuOYZA==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.1.9.tgz",
+      "integrity": "sha512-H/83xgU1l8ox+qG305p6ucmoy93qyjIPnvxGWRA7YdOoHe1tIiW9IlEu4lTdsOR7cfP1ecrwyflQSqXdXBacXA==",
       "engines": {
         "node": ">= 16"
       },
@@ -3881,6 +3882,47 @@
         "vue": "^3.2.47"
       }
     },
+    "node_modules/cdh-vue-lib/node_modules/@intlify/core-base": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.4.tgz",
+      "integrity": "sha512-vtZCt7NqWhKEtHa3SD/322DlgP5uR9MqWxnE0y8Q0tjDs9H5Lxhss+b5wv8rmuXRoHKLESNgw9d+EN9ybBbj9g==",
+      "dependencies": {
+        "@intlify/message-compiler": "9.14.4",
+        "@intlify/shared": "9.14.4"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/cdh-vue-lib/node_modules/@intlify/message-compiler": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.4.tgz",
+      "integrity": "sha512-vcyCLiVRN628U38c3PbahrhbbXrckrM9zpy0KZVlDk2Z0OnGwv8uQNNXP3twwGtfLsCf4gu3ci6FMIZnPaqZsw==",
+      "dependencies": {
+        "@intlify/shared": "9.14.4",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/cdh-vue-lib/node_modules/@intlify/shared": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.4.tgz",
+      "integrity": "sha512-P9zv6i1WvMc9qDBWvIgKkymjY2ptIiQ065PjDv7z7fDqH3J/HBRBN5IoiR46r/ujRcU7hCuSIZWvCAFCyuOYZA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/cdh-vue-lib/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -3891,6 +3933,25 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/cdh-vue-lib/node_modules/vue-i18n": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.4.tgz",
+      "integrity": "sha512-B934C8yUyWLT0EMud3DySrwSUJI7ZNiWYsEEz2gknTthqKiG4dzWE/WSa8AzCuSQzwBEv4HtG1jZDhgzPfWSKQ==",
+      "dependencies": {
+        "@intlify/core-base": "9.14.4",
+        "@intlify/shared": "9.14.4",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/chalk": {
@@ -13008,12 +13069,12 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "9.14.4",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.4.tgz",
-      "integrity": "sha512-B934C8yUyWLT0EMud3DySrwSUJI7ZNiWYsEEz2gknTthqKiG4dzWE/WSa8AzCuSQzwBEv4HtG1jZDhgzPfWSKQ==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.1.9.tgz",
+      "integrity": "sha512-N9ZTsXdRmX38AwS9F6Rh93RtPkvZTkSy/zNv63FTIwZCUbLwwrpqlKz9YQuzFLdlvRdZTnWAUE5jMxr8exdl7g==",
       "dependencies": {
-        "@intlify/core-base": "9.14.4",
-        "@intlify/shared": "9.14.4",
+        "@intlify/core-base": "11.1.9",
+        "@intlify/shared": "11.1.9",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0",
         "vue-eslint-parser": "^10.1.3",
+        "vue-i18n-extract": "^2.0.7",
         "vue-tsc": "^2.2.10"
       }
     },
@@ -5117,6 +5118,71 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dot-object": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/dot-object/-/dot-object-2.1.5.tgz",
+      "integrity": "sha512-xHF8EP4XH/Ba9fvAF2LDd5O3IITVolerVV6xvkxoM8zlGEiCUrggpAnHyOoKJKCrhvPcGATFAUwIujj7bRG5UA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^6.1.0",
+        "glob": "^7.1.6"
+      },
+      "bin": {
+        "dot-object": "bin/dot-object"
+      }
+    },
+    "node_modules/dot-object/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/dot-object/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dot-object/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/dot-object/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
@@ -7310,6 +7376,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-valid-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+      "integrity": "sha512-AhiROmoEFDSsjx8hW+5sGwgKVIORcXnrlAx/R0ZSeaPw70Vw0CqkGBBhHGL58Uox2eXnU1AnvXJl1XlyedO5bA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-what": {
@@ -13085,6 +13160,54 @@
       },
       "peerDependencies": {
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-i18n-extract": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/vue-i18n-extract/-/vue-i18n-extract-2.0.7.tgz",
+      "integrity": "sha512-i1NW5R58S720iQ1BEk+6ILo3hT6UA8mtYNNolSH4rt9345qvXdvA6GHy2+jHozdDAKHwlu9VvS/+vIMKs1UYQw==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.12",
+        "dot-object": "^2.1.4",
+        "glob": "^8.0.1",
+        "is-valid-glob": "^1.0.0",
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "vue-i18n-extract": "bin/vue-i18n-extract.js"
+      }
+    },
+    "node_modules/vue-i18n-extract/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vue-i18n-extract/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/vue-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.0",
     "vue-eslint-parser": "^10.1.3",
+    "vue-i18n-extract": "^2.0.7",
     "vue-tsc": "^2.2.10"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "nuxt": "^3.17.5",
     "uu-bootstrap": "git+https://github.com/UtrechtUniversity/UU-Bootstrap.git#v1.5.0-alpha.1",
     "vue": "^3.5.16",
+    "vue-i18n": "^11.1.9",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "i18n-extract": "vue-i18n-extract report --vueFiles './{components,pages,layouts,composables}/**/*.?(ts|vue)' --languageFiles './locales/*.?(json|yml|yaml|js)' --add",
+    "i18n-check": "python i18n-check.py"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "i18n-extract": "vue-i18n-extract report --vueFiles './{components,pages,layouts,composables}/**/*.?(ts|vue)' --languageFiles './locales/*.?(json|yml|yaml|js)' --add",
+    "i18n-extract": "vue-i18n-extract report --vueFiles \"./{components,pages,layouts,composables}/**/*.{ts,vue}\" --languageFiles \"./locales/**/*.{json,yml,yaml,js}\" --add",
     "i18n-check": "python i18n-check.py"
   },
   "dependencies": {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -4,13 +4,13 @@
 
 <template>
     <div class="uu-content">
-        <Title>MyResearch</Title>
+        <Title>{{ $t("MyResearch") }}</Title>
         <div class="uu-hero">
-            <h1>Welcome to MyResearch!</h1>
+            <h1>{{ $t("Welcome to MyResearch!") }}</h1>
         </div>
         <div class="uu-container">
             <div class="col-12">
-                <p>Welcome!</p>
+                <p>{{ $t("Welcome!") }}</p>
             </div>
         </div>
     </div>

--- a/frontend/plugins/i18n.ts
+++ b/frontend/plugins/i18n.ts
@@ -1,0 +1,27 @@
+import {createI18n} from "vue-i18n";
+import nl from "../locales/nl.json";
+
+const messages = {
+    nl
+};
+const defaultLocale = "en";
+
+/* Get locale from local storage or, if not available, from the browser
+   data, ignoring the country part (i.e. nl-NL becomes nl).
+ */
+let locale: string = localStorage.locale ?? navigator.language.split("-")[0];
+if (!(locale in messages)) {
+    locale = "en";
+}
+
+export const i18n = createI18n({
+    globalInjection: true,
+    locale,
+    messages,
+    formatFallbackMessages: true,
+    fallbackLocale: defaultLocale,
+});
+
+export default defineNuxtPlugin(({ vueApp}) => {
+    vueApp.use(i18n);
+});


### PR DESCRIPTION
As discussed with @XanderVertegaal, `vue-gettext` is not a good solution because this package causes problems in combination with the newest Nuxt version and it is not actively maintained. So we will have to go for `vue-i18n`, like we do in DIAPP.

The setup I followed is a little bit different from DIAPP:
- I added the `vue-i18n-extract` package, which automatically extracts strings and adds them to the localization files, and I set up `npm run i18n-extract` to execute this.
- I added a script to check for untranslated strings, which can be run using `npm run i18n-check`. This script can be run using GitHub Actions for automatic checks.
- In line with our decision for the backend, I chose to use the English text as keys instead of tags. According to the vue-i18n documentation, this is supported even though it is not the default use [1]. The keys (in English) are used as a fallback, even if they contain interpolated strings, which means that there is no need to maintain a separate messages file for English.

Note that even though the use of English keys is mentioned in the documentation and string interpolation is supported, I am not 100% sure we will not run into problems when using this. But I think it is worth giving it a try.

Close #8 

[1] https://vue-i18n.intlify.dev/guide/essentials/fallback.html#fallback-interpolation