### PR TITLE
Feat/dev data and dockerize codegen

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-alpine
 
 # Add git to install some requirements
-RUN apk add --no-cache git
+# Add curl to use for container healthcheck
+RUN apk add --no-cache git curl
 
 WORKDIR /usr/src/app/backend
 COPY requirements.txt .

--- a/backend/main/management/commands/create_dev_data.py
+++ b/backend/main/management/commands/create_dev_data.py
@@ -6,15 +6,16 @@ from django.apps import apps
 
 from main.models import User
 
+
 class Command(BaseCommand):
     help = "Create dev dataset for myresearch"
 
     # All models for which dev data has been implemented. Add the model to
     # this list when dev data creation has been implemented for this model.
     dev_data_models = [
-            User,
-        ]
-    
+        User,
+    ]
+
     def print(self, options, *args, **kwargs):
         if not options["silent"]:
             print(*args, **kwargs)
@@ -41,12 +42,14 @@ class Command(BaseCommand):
         for fixture in fixtures:
             call_command("loaddata", fixture)
 
-    def _check_all_models_implemented(self,):
+    def _check_all_models_implemented(
+        self,
+    ):
         """
         Gather all models from LOCAL_APPS and check if they are all present in
         dev_data_models.
         """
-        
+
         all_mr_models = []
 
         for app in settings.LOCAL_APPS:

--- a/backend/main/management/commands/create_dev_data.py
+++ b/backend/main/management/commands/create_dev_data.py
@@ -16,6 +16,10 @@ class Command(BaseCommand):
         User,
     ]
 
+    def add_arguments(self, parser):
+        parser.add_argument("--force", action="store_true")
+        parser.add_argument("--silent", action="store_true")
+
     def print(self, options, *args, **kwargs):
         if not options["silent"]:
             print(*args, **kwargs)

--- a/backend/main/management/commands/create_dev_data.py
+++ b/backend/main/management/commands/create_dev_data.py
@@ -1,0 +1,61 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management import call_command
+from django.db import transaction
+from django.apps import apps
+
+from main.models import User
+
+class Command(BaseCommand):
+    help = "Create dev dataset for myresearch"
+
+    # All models for which dev data has been implemented. Add the model to
+    # this list when dev data creation has been implemented for this model.
+    dev_data_models = [
+            User,
+        ]
+    
+    def print(self, options, *args, **kwargs):
+        if not options["silent"]:
+            print(*args, **kwargs)
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG and not options["force"]:
+            raise CommandError(
+                "Refusing to execute command unless DEBUG = True in settings.py"
+            )
+
+        self._check_all_models_implemented()
+
+        with transaction.atomic():
+            self._create_test_users(options)
+
+    def _create_test_users(self, options):
+        """
+        Create mock users for test purposes from fixtures.
+        """
+        fixtures = [
+            "main/management/commands/dev_fixtures/dev_users.json",
+        ]
+
+        for fixture in fixtures:
+            call_command("loaddata", fixture)
+
+    def _check_all_models_implemented(self,):
+        """
+        Gather all models from LOCAL_APPS and check if they are all present in
+        dev_data_models.
+        """
+        
+        all_mr_models = []
+
+        for app in settings.LOCAL_APPS:
+            for mr_model in apps.get_app_config(app).get_models():
+                all_mr_models.append(mr_model)
+
+        for mr_model in all_mr_models:
+            if mr_model not in self.dev_data_models:
+                raise CommandError(
+                    f"The model {mr_model} is not yet represented in the dev "
+                    "data creation."
+                )

--- a/backend/main/management/commands/dev_fixtures/dev_users.json
+++ b/backend/main/management/commands/dev_fixtures/dev_users.json
@@ -1,0 +1,617 @@
+[
+    {
+        "model": "main.user",
+        "pk": 1,
+        "fields": {
+            "username": "admin",
+            "password": "plain$admin",
+            "first_name": "Ad",
+            "last_name": "Min",
+            "email": "example@example.org",
+            "is_staff": true,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": true
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 2,
+        "fields": {
+            "username": "professor1",
+            "password": "plain$professor1",
+            "first_name": "Jordan",
+            "last_name": "Belfort",
+            "email": "Jordan.Belfort@harvard-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 3,
+        "fields": {
+            "username": "professor2",
+            "password": "plain$professor2",
+            "first_name": "Edo",
+            "last_name": "Storm",
+            "email": "E.Storm@harvard-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 4,
+        "fields": {
+            "username": "professor3",
+            "password": "plain$professor3",
+            "first_name": "Isaac",
+            "last_name": "Newton",
+            "email": "isaacnewton@university-example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 5,
+        "fields": {
+            "username": "professor4",
+            "password": "plain$professor4",
+            "first_name": "Georg",
+            "last_name": "Ohm",
+            "email": "georg.ohm@university-example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 6,
+        "fields": {
+            "username": "professor5",
+            "password": "plain$professor5",
+            "first_name": "John Davison",
+            "last_name": "Rockefeller",
+            "email": "John.D.Rockefeller@university-example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 7,
+        "fields": {
+            "username": "staff1",
+            "password": "plain$staff1",
+            "first_name": "Joseph",
+            "last_name": "Weeler",
+            "email": "Joseph+Weeler@university-example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 8,
+        "fields": {
+            "username": "staff2",
+            "password": "plain$staff2",
+            "first_name": "Anthony",
+            "last_name": "West",
+            "email": "Anthony_West@university-example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 9,
+        "fields": {
+            "username": "staff3",
+            "password": "plain$staff3",
+            "first_name": "Oscar",
+            "last_name": "Burton",
+            "email": "Osc@r__Burton@university-example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 10,
+        "fields": {
+            "username": "student1",
+            "password": "plain$student1",
+            "first_name": "Student",
+            "last_name": "One",
+            "email": "student1@diy.surfconext.nl",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 11,
+        "fields": {
+            "username": "student2",
+            "password": "plain$student2",
+            "first_name": "Student",
+            "last_name": "Two",
+            "email": "s1869831907@example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 12,
+        "fields": {
+            "username": "student3",
+            "password": "plain$student3",
+            "first_name": "",
+            "last_name": "Three",
+            "email": "student3@diy.surfconext.nl",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 13,
+        "fields": {
+            "username": "student4",
+            "password": "plain$student4",
+            "first_name": "Godfried",
+            "last_name": "Viggo",
+            "email": "Godfried.Viggo@unidenmark-example.dk",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 14,
+        "fields": {
+            "username": "student5",
+            "password": "plain$student5",
+            "first_name": "Daisuke",
+            "last_name": "Takahashi \u9ad9\u6a4b \u5927\u8f14",
+            "email": "U3342109@exchange-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 15,
+        "fields": {
+            "username": "student6",
+            "password": "plain$student6",
+            "first_name": "Ph\u00f9ng Th\u1ecb",
+            "last_name": "L\u1ec7 T\u01b0",
+            "email": "LeTu02@home-university-example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 16,
+        "fields": {
+            "username": "student7",
+            "password": "plain$student7",
+            "first_name": "Jaantje",
+            "last_name": "van der Sanden",
+            "email": "jsanden@uniamsterdam-example.nl",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 17,
+        "fields": {
+            "username": "student8",
+            "password": "plain$student8",
+            "first_name": "Alessandra",
+            "last_name": "G\u00f3mez Llarnas",
+            "email": "s445599@universitatmadrid-example.es",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 18,
+        "fields": {
+            "username": "student9",
+            "password": "plain$student9",
+            "first_name": "August",
+            "last_name": "Brise\u00f1o",
+            "email": "A.Briseno@universitatmadrid-example.es",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 19,
+        "fields": {
+            "username": "student10",
+            "password": "plain$student10",
+            "first_name": "Shao",
+            "last_name": "Jingy",
+            "email": "s134567@pkuni.edu-example.cn",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 20,
+        "fields": {
+            "username": "student11",
+            "password": "plain$student11",
+            "first_name": "Roman",
+            "last_name": "\u0160vejda",
+            "email": "U9088123@uni.poznantech-example.pl",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 21,
+        "fields": {
+            "username": "student12",
+            "password": "plain$student12",
+            "first_name": "Anna",
+            "last_name": "Ryb\u00ednov\u00e1",
+            "email": "U7128109@uni.poznantech-example.pl",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 22,
+        "fields": {
+            "username": "student13",
+            "password": "plain$student13",
+            "first_name": "Li Qin",
+            "last_name": "Ch'ien",
+            "email": "p0987743@pkuni.edu-example.cn",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 23,
+        "fields": {
+            "username": "student14",
+            "password": "plain$student14",
+            "first_name": "Martin",
+            "last_name": "J\u00f8rgensen",
+            "email": "jorgensen07@stockholmuni-example.se",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 24,
+        "fields": {
+            "username": "student15",
+            "password": "plain$student15",
+            "first_name": "Sander",
+            "last_name": "Kj\u00e6r",
+            "email": "kjaer11@stockholmuni-example.se",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 25,
+        "fields": {
+            "username": "student16",
+            "password": "plain$student16",
+            "first_name": "Er\u00f4ss",
+            "last_name": "Neci",
+            "email": "eross.neci@kuni.edu-example.tr",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 26,
+        "fields": {
+            "username": "student17",
+            "password": "plain$student17",
+            "first_name": "Kocsis",
+            "last_name": "Szesc\u00f5",
+            "email": "kocsis.szesco@kuni.edu-example.tr",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 27,
+        "fields": {
+            "username": "student18",
+            "password": "plain$student18",
+            "first_name": "Marjanca",
+            "last_name": "Mur\u0161i\u0107",
+            "email": "Marjanca.Mursic@kuni.edu-example.tr",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 28,
+        "fields": {
+            "username": "student19",
+            "password": "plain$student19",
+            "first_name": "Petra",
+            "last_name": "Penttil\u00e4",
+            "email": "ppentila@hotmail-example.org",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 29,
+        "fields": {
+            "username": "student20",
+            "password": "plain$student20",
+            "first_name": "J\u00f3ney",
+            "last_name": "Ing\u00f3lfsd\u00f3ttir",
+            "email": "Joney.Ingolfsdottir@unidenmark-example.dk",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 30,
+        "fields": {
+            "username": "student21",
+            "password": "plain$student21",
+            "first_name": "Pietje",
+            "last_name": "Puk",
+            "email": "Pietje.puk@exmplebilbioharderwijk.nl",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 31,
+        "fields": {
+            "username": "teacher1",
+            "password": "plain$teacher1",
+            "first_name": "Joseph",
+            "last_name": "Stiglitz",
+            "email": "J.E.Stiglitz@harvard-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 32,
+        "fields": {
+            "username": "teacher2",
+            "password": "plain$teacher2",
+            "first_name": "Paul",
+            "last_name": "Krugman",
+            "email": "P.R.Krugman@harvard-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 33,
+        "fields": {
+            "username": "teacher3",
+            "password": "plain$teacher3",
+            "first_name": "Ben",
+            "last_name": "Bernanke",
+            "email": "B.S.Bernanke@yale-uni-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 34,
+        "fields": {
+            "username": "teacher4",
+            "password": "plain$teacher4",
+            "first_name": "Alan",
+            "last_name": "Greenspan",
+            "email": "A.Greenspan@yale-uni-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 35,
+        "fields": {
+            "username": "teacher5",
+            "password": "plain$teacher5",
+            "first_name": "Andr\u00e9-Marie",
+            "last_name": "Amp\u00e8re",
+            "email": "am_ampere@electrical-uni-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 36,
+        "fields": {
+            "username": "teacher6",
+            "password": "plain$teacher6",
+            "first_name": "Wilhelm",
+            "last_name": "R\u00f6ntgen",
+            "email": "w_rontgen@electrical-uni-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 37,
+        "fields": {
+            "username": "teacher7",
+            "password": "plain$teacher7",
+            "first_name": "Michael",
+            "last_name": "Faraday",
+            "email": "m_faraday@electrical-uni-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 38,
+        "fields": {
+            "username": "teacher8",
+            "password": "plain$teacher8",
+            "first_name": "Nikola",
+            "last_name": "Tesla",
+            "email": "n_tesla@electrical-uni-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 39,
+        "fields": {
+            "username": "teacher9",
+            "password": "plain$teacher9",
+            "first_name": "Bill",
+            "last_name": "Gates",
+            "email": "bill.gates@stanford-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 40,
+        "fields": {
+            "username": "teacher10",
+            "password": "plain$teacher10",
+            "first_name": "Steve",
+            "last_name": "Jobs",
+            "email": "steve.jobs@stanford-example.edu",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    },
+    {
+        "model": "main.user",
+        "pk": 41,
+        "fields": {
+            "username": "caesar",
+            "password": "plain$caesar",
+            "first_name": "Caesar",
+            "last_name": "Bruttius",
+            "email": "caesar.bruttius@spqr.ro",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2023-05-02T08:27:53.470Z",
+            "is_superuser": false
+        }
+    }
+]

--- a/backend/myresearch/settings.py
+++ b/backend/myresearch/settings.py
@@ -26,9 +26,7 @@ SECRET_KEY = "django-insecure-s8e=1!*6dzct5!vn$0%qdc!x4$_vhd895g0a1#e$_v+oqbvvyq
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = [
-    "mr-django", '.localhost', '127.0.0.1', '[::1]'
-]
+ALLOWED_HOSTS = ["mr-django", ".localhost", "127.0.0.1", "[::1]"]
 INTERNAL_IPS = [
     "127.0.0.1",
 ]
@@ -41,19 +39,23 @@ LOCAL_APPS = [
     "main",
 ]
 
-INSTALLED_APPS = [
-    "django.contrib.admin",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-    ] + LOCAL_APPS + [
-    # Cors headers
-    "corsheaders",
-    # GraphQL
-    "graphene_django",
-]
+INSTALLED_APPS = (
+    [
+        "django.contrib.admin",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.sessions",
+        "django.contrib.messages",
+        "django.contrib.staticfiles",
+    ]
+    + LOCAL_APPS
+    + [
+        # Cors headers
+        "corsheaders",
+        # GraphQL
+        "graphene_django",
+    ]
+)
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/backend/myresearch/settings.py
+++ b/backend/myresearch/settings.py
@@ -34,6 +34,11 @@ INTERNAL_IPS = [
 
 # Application definition
 
+LOCAL_APPS = [
+    # Main local app
+    "main",
+]
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -41,8 +46,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    # Main local app
-    "main",
+    ] + LOCAL_APPS + [
     # Cors headers
     "corsheaders",
     # GraphQL

--- a/backend/myresearch/settings.py
+++ b/backend/myresearch/settings.py
@@ -26,7 +26,9 @@ SECRET_KEY = "django-insecure-s8e=1!*6dzct5!vn$0%qdc!x4$_vhd895g0a1#e$_v+oqbvvyq
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    "mr-django", '.localhost', '127.0.0.1', '[::1]'
+]
 INTERNAL_IPS = [
     "127.0.0.1",
 ]

--- a/backend/myresearch/settings.py
+++ b/backend/myresearch/settings.py
@@ -35,7 +35,6 @@ INTERNAL_IPS = [
 # Application definition
 
 LOCAL_APPS = [
-    # Main local app
     "main",
 ]
 

--- a/backend/myresearch/urls.py
+++ b/backend/myresearch/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 """
 
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import path, include
 
 from graphene_django.views import GraphQLView
@@ -25,4 +26,6 @@ from django.views.decorators.csrf import csrf_exempt
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("api.urls")),
+    # Used as a healthcheck by the docker container
+    path('healthcheck/', lambda r: HttpResponse())
 ]

--- a/backend/myresearch/urls.py
+++ b/backend/myresearch/urls.py
@@ -26,6 +26,6 @@ from django.views.decorators.csrf import csrf_exempt
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("api.urls")),
-    # Used as a healthcheck by the docker container
+    # Used for a healthcheck by the Docker container.
     path("healthcheck/", lambda r: HttpResponse()),
 ]

--- a/backend/myresearch/urls.py
+++ b/backend/myresearch/urls.py
@@ -27,5 +27,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("api.urls")),
     # Used as a healthcheck by the docker container
-    path('healthcheck/', lambda r: HttpResponse())
+    path("healthcheck/", lambda r: HttpResponse()),
 ]

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,7 +32,7 @@ services:
     profiles: ["dev"]
     build: ./backend
     healthcheck:
-      test: "curl -f localhost:8000"
+      test: "curl -f localhost:8000/healthcheck/"
     volumes:
       - ./backend:/usr/src/app/backend
       - bapyca:/usr/src/app/backend/__pycache__
@@ -53,7 +53,10 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.dev
-    command: npm run dev
+    entrypoint: ./start_dev.sh
+    depends_on:
+      django-dev:
+        condition: service_healthy
     expose:
       - "3000"
     ports:
@@ -66,6 +69,7 @@ services:
     environment:
       # Allows Nuxt to be accessible from the outside.
       - HOST=0.0.0.0
+      - CODEGEN_SCHEMA=http://mr-django:8000/api/graphql
 
   vue-prod:
     image: mr-vue-prod

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -12,6 +12,9 @@ WORKDIR /app
 # Copy package.json and package-lock.json (if available).
 COPY package*.json ./
 
+# Copy start_dev.sh script
+COPY start_dev.sh ./
+
 # Install project dependencies
 RUN npm install
 

--- a/frontend/start_dev.sh
+++ b/frontend/start_dev.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+npm run dev &
+npm run codegen


### PR DESCRIPTION
So are two fairly unrelated issues in one branch, but they compliment each other nicely.

fixes #23:

So that was my initial plan for this branch, to get the testdata gen started. I pretty much copied the design from the DIAPP test data gen, but removed everything not needed. I also implemented @miggol's suggestion to check for missing models. The way I implemented it now, is that you have to manually update the list `dev_data_models` after you have implemented a new model in the dev data generation. This then get compared against a list which gets generated in `_check_all_models_implemented()`, which gets all models for all `settings.LOCAL_APPS`. This is all working fine. For now we only generate users.

fixes #39:

I also really wanted to automate codegen in the docker setup, so we can use http://localhost:3000/gql_tst/ to see the results of the generated testdata in the frontend. I had to tinker quite a bit with the compose file to get this to work, with generous help from @XanderVertegaal, but it seems to work now. Some things to note:

- the command for vue-dev has been replaced with a .sh file, for easier maintainability.
- As codegen needs the backend to run, vue-dev now depends on django-dev.
- While implementing this condition, I found that django-dev's healthcheck was not working. I now also install curl in the dockerfile to perform the healthcheck.
- As the healthcheck needs a 200 request, we needed to receive this somewhere from the backend. I implemented a blank page for this on http://localhost:8000/healthcheck/ (though using admin for this also works ...) I am not sure if this is bad. It's something I saw online. Let me know what you think of this.

Anyway, it all works, so that is good. Any suggestions for easter eggs in dev_users.json?