### PR TITLE
Doc: create DB script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,21 @@ local_settings.py file, which contains the following settings:
     CSRF_TRUSTED_ORIGINS = ["http://*:3000"]
     ```
 
-6. Create a new local development database. The Django development server 
-expects a database with the following details. (This can be changed as needed 
-in `settings.py`):
+6. Create a new local development database. The first PostgreSQL start-up will
+normally do this for you, but in case you need to do this manually, follow this
+step. The Django development server expects a database with the following
+details. (This can be changed as needed in `settings.py`):
 - DB name: `myresearch`
 - Host: `localhost`
 - Port: `5432`
 - User: `myresearch`
 - Password: `myresearch`
 
-The `create_db.sql` script in the root of the repository can be used to create 
-the database and user with the correct permissions. Run it as follows.
+The file `backend/create_db.sql` can be used to create the database and user 
+with the correct permissions. Run it as follows.
 
 ```bash
-psql -U <your-postgres-username> -f create_db.sql
+psql -U <your-postgres-username> -f backend/create_db.sql
 ```
 
 Note that this is not needed if you are using the provided Docker setup. Also, 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The `create_db.sql` script in the root of the repository can be used to create
 the database and user with the correct permissions. Run it as follows.
 
 ```bash
-psql -U postgres -f create_db.sql
+psql -U <your-postgres-username> -f create_db.sql
 ```
 
 Note that this is not needed if you are using the provided Docker setup. Also, 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ The differences are outlined below.
 
 4. Open your browser and navigate to `http://localhost:3000` to visit the application!
 
-
     (TODO: add backend install instructions).
 
 5. For development, the backend requires supplementing the settings.py with a
@@ -60,6 +59,26 @@ local_settings.py file, which contains the following settings:
 
     CSRF_TRUSTED_ORIGINS = ["http://*:3000"]
     ```
+
+6. Create a new local development database. The Django development server 
+expects a database with the following details. (This can be changed as needed 
+in `settings.py`):
+- DB name: `myresearch`
+- Host: `localhost`
+- Port: `5432`
+- User: `myresearch`
+- Password: `myresearch`
+
+The `create_db.sql` script in the root of the repository can be used to create 
+the database and user with the correct permissions. Run it as follows.
+
+```bash
+psql -U postgres -f create_db.sql
+```
+
+Note that this is not needed if you are using the provided Docker setup. Also, 
+make sure to never use these standard settings in a production environment.
+
 
 ## Running the application in Docker
 

--- a/create_db.sql
+++ b/create_db.sql
@@ -1,0 +1,5 @@
+CREATE USER myresearch WITH createdb PASSWORD 'myresearch';
+CREATE DATABASE myresearch;
+GRANT ALL ON DATABASE myresearch TO myresearch;
+GRANT ALL ON SCHEMA public TO myresearch;
+ALTER DATABASE myresearch OWNER TO myresearch;

--- a/create_db.sql
+++ b/create_db.sql
@@ -1,5 +1,0 @@
-CREATE USER myresearch WITH createdb PASSWORD 'myresearch';
-CREATE DATABASE myresearch;
-GRANT ALL ON DATABASE myresearch TO myresearch;
-GRANT ALL ON SCHEMA public TO myresearch;
-ALTER DATABASE myresearch OWNER TO myresearch;


### PR DESCRIPTION
Our RSL 'cookie cutter' project template contains a SQL script that helps new users set up a dev database, so I've added it here too. This may save developers (and ourselves, after a clean system install) getting MyResearch to run locally.