### PR TITLE
Feature/create dev data studies

### DIFF
--- a/backend/main/management/commands/create_dev_data.py
+++ b/backend/main/management/commands/create_dev_data.py
@@ -8,6 +8,7 @@ from django.core.management import call_command
 from django.db import transaction
 
 from main.models import User
+from research.models import Study
 from form.models import (
     BaseQuestion,
     MRForm,
@@ -41,6 +42,9 @@ MAX_STEP_DEPTH = 3
 
 ALL_QUESTIONS = ["select", "text", "true_false", "date", "number", "file_upload"]
 
+# Min/max number of studies per user
+MIN_STUDIES_PER_USER = 1
+MAX_STUDIES_PER_USER = 4
 
 class Command(BaseCommand):
     help = "Create dev dataset for myresearch"
@@ -65,6 +69,7 @@ class Command(BaseCommand):
         StepInfoText,
         StepInfoQuestion,
         BaseQuestion,
+        Study,
     ]
 
     def add_arguments(self, parser):
@@ -86,6 +91,7 @@ class Command(BaseCommand):
         self._create_test_users(options)
 
         with transaction.atomic():
+            self._create_studies(options)
             form = self._generate_form(options)
             self._generate_steps(options, form)
             self._generate_questions(options, form)
@@ -297,6 +303,23 @@ class Command(BaseCommand):
         for fixture in fixtures:
             call_command("loaddata", fixture)
 
+    def _create_studies(self, options):
+        """
+        Create mock studies for each user
+        """
+
+        for user in tqdm(User.objects.all(), "Generating studies ..."):
+
+            num_studies = self.faker.random_int(
+                MIN_STUDIES_PER_USER, MAX_STUDIES_PER_USER
+            )
+
+            for _ in range(num_studies):
+                Study.objects.create(
+                    created_by = user,
+                    title = self.faker_nl.sentence(nb_words=5),
+                )
+            
     def _check_all_models_implemented(
         self,
     ):

--- a/backend/main/management/commands/create_dev_data.py
+++ b/backend/main/management/commands/create_dev_data.py
@@ -284,6 +284,11 @@ class Command(BaseCommand):
     def _create_test_users(self, options):
         """
         Create mock users for test purposes from fixtures.
+
+        NOTE: These users are the same as the ones provided by the
+        Dev-IDP and must be kept the same!
+
+        TODO: Find a way to just import them directly from the Dev-IDP
         """
         fixtures = [
             "main/management/commands/dev_fixtures/dev_users.json",

--- a/backend/main/management/commands/create_dev_data.py
+++ b/backend/main/management/commands/create_dev_data.py
@@ -46,6 +46,7 @@ ALL_QUESTIONS = ["select", "text", "true_false", "date", "number", "file_upload"
 MIN_STUDIES_PER_USER = 1
 MAX_STUDIES_PER_USER = 4
 
+
 class Command(BaseCommand):
     help = "Create dev dataset for myresearch"
 
@@ -316,10 +317,10 @@ class Command(BaseCommand):
 
             for _ in range(num_studies):
                 Study.objects.create(
-                    created_by = user,
-                    title = self.faker_nl.sentence(nb_words=5),
+                    created_by=user,
+                    title=self.faker_nl.sentence(nb_words=5),
                 )
-            
+
     def _check_all_models_implemented(
         self,
     ):

--- a/backend/main/management/commands/dev_fixtures/dev_users.json
+++ b/backend/main/management/commands/dev_fixtures/dev_users.json
@@ -11,7 +11,8 @@
             "is_staff": true,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": true
+            "is_superuser": true,
+            "groups": [1,2]
         }
     },
     {
@@ -26,7 +27,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": [1]
         }
     },
     {
@@ -35,13 +37,14 @@
         "fields": {
             "username": "professor2",
             "password": "plain$professor2",
-            "first_name": "Edo",
-            "last_name": "Storm",
-            "email": "E.Storm@harvard-example.edu",
+            "first_name": "Steve",
+            "last_name": "Wynn",
+            "email": "S.Wynn@harvard-example.edu",
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": [1]
         }
     },
     {
@@ -56,7 +59,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": [1]
         }
     },
     {
@@ -71,7 +75,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": [2]
         }
     },
     {
@@ -86,7 +91,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": [2]
         }
     },
     {
@@ -101,7 +107,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -116,7 +123,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -131,7 +139,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -146,7 +155,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -161,7 +171,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -176,7 +187,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -191,7 +203,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -206,7 +219,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -221,7 +235,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -236,7 +251,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -251,7 +267,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -266,7 +283,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -281,7 +299,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -296,7 +315,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -311,7 +331,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -326,7 +347,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -341,7 +363,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -356,7 +379,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -371,7 +395,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -386,7 +411,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -401,7 +427,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -416,7 +443,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -431,7 +459,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -446,7 +475,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -461,7 +491,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -476,7 +507,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -491,7 +523,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -506,7 +539,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -521,7 +555,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -536,7 +571,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -551,7 +587,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -566,7 +603,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -581,7 +619,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -596,7 +635,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     },
     {
@@ -611,7 +651,8 @@
             "is_staff": false,
             "is_active": true,
             "date_joined": "2023-05-02T08:27:53.470Z",
-            "is_superuser": false
+            "is_superuser": false,
+            "groups": []
         }
     }
 ]

--- a/backend/main/utils/permission_utils.py
+++ b/backend/main/utils/permission_utils.py
@@ -34,8 +34,8 @@ class BaseMRManager(models.Manager):
 
     def _viewable_objects(self, user: User):
         # Needs to be overwritten for a specific object's permissions
-        return self
+        return self.all()
 
     def _editable_objects(self, user: User):
         # Needs to be overwritten for a specific object's permissions
-        return self
+        return self.all()

--- a/backend/research/models.py
+++ b/backend/research/models.py
@@ -7,7 +7,7 @@ from django.db import models
 class StudyManager(BaseMRManager):
     def _viewable_objects(self, user: User):
         if user.is_privacy_officer or user.is_fetc_member:
-            return self
+            return self.all()
         return self.filter(created_by=user)
 
     def _editable_objects(self, user: User):


### PR DESCRIPTION
This was useful for implementing the lists. A small lil' PR ...

- I got the user fixture to correspond 1:1 to the users in the Dev IDP and added groups to them.
- I added a function for creating studies in create_dev_data. (I'm not sure if  we'll keep these study models ... But for now this is useful. Also the create_dev_data was complaining about this not being implemented. I tried to follow your lead on how to approach this @XanderVertegaal. I am not really sure if this should be an atomic transaction or not, but felt it probably should be?
- I found a bug when all objects had to get returned. Adding `.all()` to the return value of `_accessible_objects` fixes this.

Each bullet point corresponds to a commit. Happy reviewing :) 