### PR TITLE
Run npm install on frontend container start

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The differences are outlined below.
 | Ports available | 3000 (frontend)           | 5000 (NGINX), 3000 (frontend)          | 5000 (NGINX)                                  |
 | Logging | Console                   | TBD                                    | TBD                                           |
 
+In development mode, the backend dependencies are included in the Docker image and only
+updated when building the container, while the frontend dependencies are mounted as a
+volume and updated automatically every time the container starts.
 
 ## Running the application locally
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -9,14 +9,7 @@ RUN apk add python3
 # Set the working directory in the container.
 WORKDIR /app
 
-# Copy package.json and package-lock.json (if available).
-COPY package*.json ./
-
-# Copy start_dev.sh script
-COPY start_dev.sh ./
-
-# Install project dependencies
-RUN npm install
+# Source is not copied because it is mounted as a volume
 
 # Nuxt 3 default port is 3000.
 # Does not actually expose the port but documents it.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
                 "@vuelidate/core": "^2.0.3",
                 "@vuelidate/validators": "^2.0.4",
                 "apollo-client": "^2.6.10",
-                "bootstrap": "^5.3.7",
+                "bootstrap": "^5.3.8",
                 "cdh-vue-lib": "git+https://github.com/CentreForDigitalHumanities/Vue-lib.git#0.6.0",
                 "codegen": "^0.1.0",
                 "graphql": "^15.10.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.4",
         "apollo-client": "^2.6.10",
-        "bootstrap": "^5.3.7",
+        "bootstrap": "^5.3.8",
         "cdh-vue-lib": "git+https://github.com/CentreForDigitalHumanities/Vue-lib.git#0.6.0",
         "codegen": "^0.1.0",
         "graphql": "^15.10.1",

--- a/frontend/start_dev.sh
+++ b/frontend/start_dev.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+npm install
 npm run dev &
 npm run codegen


### PR DESCRIPTION
This fix solves the problem that npm dependencies were not automatically installed when `package.json` was altered. As Michael suggested, the dependencies are now installed as the first step of the `start_container.sh` script, so this happens every time the container starts. The dependencies are no longer installed during image building. This did not work, because the `node_modules` directory was mounted as a volume and as such they were not part of the image.

Note that the backend still installs the dependencies while the image is being built: here the dependencies are installed as part of the Python installation, which lives in the image. I have documented this difference in the README file.

I updated the Bootstrap dependency to the latest point release to test this fix.