### PR TITLE
Feature/update question order in admin

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -2,7 +2,6 @@ import pytest
 
 from django.contrib.auth import get_user_model
 
-
 User = get_user_model()
 
 

--- a/backend/form/admin.py
+++ b/backend/form/admin.py
@@ -132,7 +132,7 @@ class StepAdmin(admin.ModelAdmin):
     search_fields = ("name_nl", "name_en", "slug", "description_nl", "description_en")
     prepopulated_fields = {"slug": ("name_nl", "name_en")}
     fieldsets = (
-        (None, {"fields": ("name_nl", "name_en", "slug", "description")}),
+        (None, {"fields": ("name_nl", "name_en", "slug", "description_nl", "description_en")}),
         (
             "Hierarchy",
             {

--- a/backend/form/admin.py
+++ b/backend/form/admin.py
@@ -132,7 +132,18 @@ class StepAdmin(admin.ModelAdmin):
     search_fields = ("name_nl", "name_en", "slug", "description_nl", "description_en")
     prepopulated_fields = {"slug": ("name_nl", "name_en")}
     fieldsets = (
-        (None, {"fields": ("name_nl", "name_en", "slug", "description_nl", "description_en")}),
+        (
+            None,
+            {
+                "fields": (
+                    "name_nl",
+                    "name_en",
+                    "slug",
+                    "description_nl",
+                    "description_en",
+                )
+            },
+        ),
         (
             "Hierarchy",
             {

--- a/backend/form/admin.py
+++ b/backend/form/admin.py
@@ -1,9 +1,12 @@
 from django.contrib import admin
+
+from form.forms import StepAdminForm
 from .models import (
     MRForm,
     Step,
     StepInfoQuestion,
     StepInfoText,
+    BaseQuestion,
     SelectQuestion,
     SelectOption,
     TrueFalseQuestion,
@@ -92,6 +95,20 @@ class QuestionResponseInline(admin.StackedInline):
     readonly_fields = ("answered_at",)
 
 
+class QuestionInline(admin.TabularInline):
+    model = BaseQuestion
+    extra = 0
+    fields = ("id", "text", "required", "description")
+    readonly_fields = ("id", "text", "required", "description")
+    can_delete = False
+    show_change_link = True
+    verbose_name = "Question"
+    verbose_name_plural = "Questions in This Step"
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
 # Main model admins
 @admin.register(MRForm)
 class MRFormAdmin(admin.ModelAdmin):
@@ -123,13 +140,22 @@ class StepAdmin(admin.ModelAdmin):
                 "description": "Set either 'form' (for top-level steps) OR 'parent' (for substeps), not both.",
             },
         ),
+        (
+            "Question Order",
+            {
+                "fields": ("question_order",),
+                "description": "Set the display order of questions. Use the question IDs shown in the Questions inline below.",
+            },
+        ),
     )
     inlines = [
         SubstepInline,
         StepInfoQuestionInline,
         StepInfoTextInline,
+        QuestionInline,
         StepConditionInline,
     ]
+    form = StepAdminForm
 
     def created_at_display(self, obj):
         # Steps don't have created_at, but showing placeholder for structure

--- a/backend/form/forms.py
+++ b/backend/form/forms.py
@@ -53,7 +53,9 @@ class StepAdminForm(ModelForm):
         # Validate that the provided IDs exist.
         available_ids = [question.id for question in self.instance.questions.all()]
         invalid_ids = [
-            question_id for question_id in requested_order if question_id not in available_ids
+            question_id
+            for question_id in requested_order
+            if question_id not in available_ids
         ]
 
         if invalid_ids:

--- a/backend/form/forms.py
+++ b/backend/form/forms.py
@@ -1,0 +1,81 @@
+from django.forms import ModelForm, CharField, ValidationError, Textarea
+
+from form.models import Step
+
+
+class StepAdminForm(ModelForm):
+    """
+    Custom form for Steps in the Django Admin interface. Adds a field 'question
+    order' to the form, which allows a user to set the order of questions
+    within a step.
+    """
+
+    question_order = CharField(
+        max_length=255,
+        help_text="Comma-separated list of question IDs in desired order, e.g. '3,1,2'.",
+        label="Question order",
+        required=False,
+        widget=Textarea(attrs={"cols": "75", "rows": "1"}),
+    )
+
+    class Meta:
+        model = Step
+        fields = []
+
+    # Prepopulate question_order with current order if editing a step.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            current_order = self.instance.get_basequestion_order()
+            if current_order:
+                self.initial["question_order"] = ",".join(map(str, current_order))
+
+    def clean_question_order(self):
+        """
+        Make sure that the provided question IDs are valid and exist.
+        """
+        question_order: str = self.cleaned_data.get("question_order", "")
+        if not question_order:
+            return question_order
+
+        # Get the requested order of question IDs as a list of integers.
+        requested_order = []
+        for id_str in question_order.split(","):
+            id_str = id_str.strip()
+            if not id_str:
+                continue
+            if not id_str.isdigit():
+                raise ValidationError(
+                    f"Invalid question ID format: '{id_str}'. Must be numeric."
+                )
+            requested_order.append(int(id_str))
+
+        # Validate that the provided IDs exist.
+        available_ids = [question.id for question in self.instance.questions.all()]
+        invalid_ids = [
+            question_id for question_id in requested_order if question_id not in available_ids
+        ]
+
+        if invalid_ids:
+            raise ValidationError(
+                f"Invalid question IDs: {', '.join(map(str, invalid_ids))}. "
+                f"Available IDs: {', '.join(map(str, available_ids))}"
+            )
+
+        return question_order
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        question_order = self.cleaned_data.get("question_order", "")
+
+        if question_order:
+            requested_order = [
+                int(id_str)
+                for id_str in question_order.split(",")
+                if id_str.strip().isdigit()
+            ]
+            instance.set_basequestion_order(requested_order)
+
+        if commit:
+            instance.save()
+        return instance

--- a/backend/form/forms.py
+++ b/backend/form/forms.py
@@ -63,7 +63,15 @@ class StepAdminForm(ModelForm):
                 f"Invalid question IDs: {', '.join(map(str, invalid_ids))}. "
                 f"Available IDs: {', '.join(map(str, available_ids))}"
             )
+        
+        # Make sure that all available IDs are included.
+        missing_ids = set(available_ids) - set(requested_order)
 
+        if missing_ids:
+            raise ValidationError(
+                f"Missing IDs: {', '.join(map(str, missing_ids))}. "
+                f"Available IDs: {', '.join(map(str, available_ids))}"
+            )
         return question_order
 
     def save(self, commit=True):

--- a/backend/form/forms.py
+++ b/backend/form/forms.py
@@ -63,7 +63,7 @@ class StepAdminForm(ModelForm):
                 f"Invalid question IDs: {', '.join(map(str, invalid_ids))}. "
                 f"Available IDs: {', '.join(map(str, available_ids))}"
             )
-        
+
         # Make sure that all available IDs are included.
         missing_ids = set(available_ids) - set(requested_order)
 

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 


### PR DESCRIPTION
Adds a StepAdminForm, mostly ~stolen~ adapted from DIAPP's ReportFieldAdmin, that lets you set the order of questions within a step. It is a bit clunky, but it works well enough for our purposes I think.