### PR TITLE
Add debounce and dedupe requests

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -2,7 +2,6 @@ import pytest
 
 from django.contrib.auth import get_user_model
 
-
 User = get_user_model()
 
 

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/frontend/components/shared/FormWrapper.vue
+++ b/frontend/components/shared/FormWrapper.vue
@@ -27,13 +27,24 @@ const props = defineProps<Props>();
 const queried = computed(() => props.queriedForm);
 const { formObject, validationRules } = useFormState(queried);
 
+// Debounced submit function
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+const debouncedSubmit = () => {
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+        submitForm();
+    }, 300);
+};
+
 // Watch for changes in the form and mutate and refetch
 // This is just a proof-of-concept and our mutation/refetching strategy needs to
 // get refined.
 watch(
     formObject,
     () => {
-        submitForm();
+        debouncedSubmit();
     },
     { deep: true },
 );
@@ -60,23 +71,36 @@ const UPDATE_USER_FORM = graphql(`
 const { mutate: mutateForm } =
     useMutation<UpdateUserFormMutation>(UPDATE_USER_FORM);
 
+const submittedInput = ref<string>("");
+
 function submitForm(): void {
     const formData = formObject.value;
-    if (formData) {
-        const inputData = FormDataToMutationInput(formData);
-        mutateForm(inputData)
-            .then(() => {
-                void props.refetchForm();
-            })
-            .catch((error: unknown) => {
-                console.error("Error updating form:", error);
-            });
+    if (!formData) {
+        return;
     }
+
+    const inputData = FormDataToMutationInput(formData);
+
+    const newInputData = JSON.stringify(inputData);
+    const oldInputData = submittedInput.value;
+
+    // No changes detected. Skip submission.
+    if (newInputData === oldInputData) {
+        return;
+    }
+
+    submittedInput.value = newInputData;
+
+    mutateForm(inputData)
+        .then(() => {
+            void props.refetchForm();
+        })
+        .catch((error: unknown) => {
+            console.error("Error updating form:", error);
+        });
 }
 
-function FormDataToMutationInput(
-    formData: FormWithValues,
-): UserFormInput {
+function FormDataToMutationInput(formData: FormWithValues): UserFormInput {
     // Utility function to transform our form into the expected input for our mutation
 
     // First collect all questions


### PR DESCRIPTION
This is an addition to #111, which should be merged first. It makes sure submissions are debounced with 300ms (we can adjust this of course). It also adds a small mechanism that compares mutation inputs and avoids duplicate mutations.

There is still the issue that changes made between mutations and refetches are sometimes lost: you can test this by typing in a text field: some characters are 'eaten'/removed. This issue will become less problematic once we implement more sophisticated logic to determine when a mutation should be sent (e.g. by using an 'onBlur' event, or having the user click a 'Submit' or 'Next Step' button).