### PR TITLE
feat: docker settings to allow for debugging + django-extensions for shell_plus

### DIFF
--- a/backend/myresearch/settings/generic_settings.py
+++ b/backend/myresearch/settings/generic_settings.py
@@ -43,7 +43,7 @@ INSTALLED_APPS = (
         "corsheaders",
         "graphene_django",
         "modeltranslation",
-        "django-extensions",
+        "django_extensions",
     ]
 )
 

--- a/backend/myresearch/settings/generic_settings.py
+++ b/backend/myresearch/settings/generic_settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = (
         "corsheaders",
         "graphene_django",
         "modeltranslation",
+        "django-extensions",
     ]
 )
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -64,6 +64,8 @@ services:
       python manage.py migrate &&
       python manage.py runserver 0.0.0.0:8000
       "
+    stdin_open: true
+    tty: true
     ports:
       - "8000:8000"
     environment:


### PR DESCRIPTION
I know both @miggol and me are quite fond of using breakpoints and using pdb for debugging. This wasn't possible, but using these settings for the dev container does allow for this when attaching to the django container. It is still a bit annoying that the healthcheck can interfere ... But this is an improvement for now.