### PR TITLE
Outfactor dev data generation completeness check to test

### DIFF
--- a/backend/form/services/form_evaluator_test.py
+++ b/backend/form/services/form_evaluator_test.py
@@ -648,8 +648,8 @@ class TestFormEvaluatorSubmission:
         newer = UserFormSubmission.objects.create(user=test_user, form=form)
 
         evaluator = FormEvaluator(form, test_user)
-
-        assert evaluator.submission == newer
+        assert evaluator.submission
+        assert evaluator.submission.pk == newer.pk
 
     def test_get_user_answer(self, form, test_user, trigger_question):
         """Test get_user_answer retrieves correct answer."""

--- a/backend/main/management/commands/create_dev_data.py
+++ b/backend/main/management/commands/create_dev_data.py
@@ -1,7 +1,6 @@
 from tqdm import tqdm
 from faker import Faker
 
-from django.apps import apps
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
@@ -10,7 +9,6 @@ from django.db import transaction
 from main.models import User
 from research.models import Study
 from form.models import (
-    BaseQuestion,
     MRForm,
     Step,
     StepInfoText,
@@ -55,29 +53,9 @@ class Command(BaseCommand):
     faker_nl = faker["nl_NL"]
     faker_en = faker["en_GB"]
 
-    # All models for which dev data has been implemented. Add the model to
-    # this list when dev data creation has been implemented for this model.
-    dev_data_models = [
-        User,
-        MRForm,
-        Step,
-        DateQuestion,
-        FileUploadQuestion,
-        NumberQuestion,
-        SelectOption,
-        SelectQuestion,
-        TextQuestion,
-        TrueFalseQuestion,
-        StepInfoText,
-        StepInfoQuestion,
-        BaseQuestion,
-        Study,
-    ]
-
     def add_arguments(self, parser):
         parser.add_argument("--force", action="store_true")
         parser.add_argument("--silent", action="store_true")
-        parser.add_argument("--ignore-missing-models", action="store_true")
 
     def print(self, options, *args, **kwargs):
         if not options["silent"]:
@@ -89,9 +67,6 @@ class Command(BaseCommand):
                 "Refusing to execute command unless DEBUG = True in settings.py"
             )
 
-        if not options["ignore_missing_models"]:
-            self._check_all_models_implemented()
-
         self._create_test_users(options)
 
         with transaction.atomic():
@@ -100,19 +75,21 @@ class Command(BaseCommand):
             self._generate_steps(options, form)
             self._generate_questions(options, form)
 
+        self.print(options, "Dev data generation complete!")
+
     def _generate_form(self, options) -> MRForm:
         """
         Generate a root MRForm with top-level steps.
         """
 
-        print("Generating root form with top-level steps...")
+        self.print(options, "Generating root form with top-level steps...")
 
         form = MRForm.objects.create(
             name_nl=self.faker_nl.sentence(nb_words=5),
             name_en=self.faker_en.sentence(nb_words=5),
         )
 
-        print("Done!")
+        self.print(options, "Done!")
 
         return form
 
@@ -136,6 +113,7 @@ class Command(BaseCommand):
             for _ in tqdm(
                 range(num_substeps),
                 desc=f"Generating substeps for step {step.name[:10]} (depth: {depth})",
+                disable=options["silent"],
             ):
                 substep = Step.objects.create(
                     parent=step,
@@ -154,7 +132,11 @@ class Command(BaseCommand):
             MIN_STEPS_IN_ROOT_FORM, MAX_STEPS_IN_ROOT_FORM
         )
 
-        for _ in tqdm(range(num_steps), desc="Generating top-level steps..."):
+        for _ in tqdm(
+            range(num_steps),
+            desc="Generating top-level steps...",
+            disable=options["silent"],
+        ):
             step = Step.objects.create(
                 form=form,
                 name_nl=self.faker_nl.sentence(nb_words=5),
@@ -270,7 +252,9 @@ class Command(BaseCommand):
 
         all_steps = _get_all_steps(form)
 
-        for step in tqdm(all_steps, desc="Generating questions..."):
+        for step in tqdm(
+            all_steps, desc="Generating questions...", disable=options["silent"]
+        ):
             number_of_questions = self.faker.random_int(
                 MIN_QUESTIONS_IN_STEP, MAX_QUESTIONS_IN_STEP
             )
@@ -312,7 +296,9 @@ class Command(BaseCommand):
         Create mock studies for each user
         """
 
-        for user in tqdm(User.objects.all(), "Generating studies ..."):
+        for user in tqdm(
+            User.objects.all(), "Generating studies ...", disable=options["silent"]
+        ):
 
             num_studies = self.faker.random_int(
                 MIN_STUDIES_PER_USER, MAX_STUDIES_PER_USER
@@ -329,24 +315,3 @@ class Command(BaseCommand):
                 )
                 submission.study = study  # type: ignore
                 submission.save()
-
-    def _check_all_models_implemented(
-        self,
-    ):
-        """
-        Gather all models from LOCAL_APPS and check if they are all present in
-        dev_data_models.
-        """
-
-        all_mr_models = []
-
-        for app in settings.LOCAL_APPS:
-            for mr_model in apps.get_app_config(app).get_models():
-                all_mr_models.append(mr_model)
-
-        for mr_model in all_mr_models:
-            if mr_model not in self.dev_data_models:
-                raise CommandError(
-                    f"The model {mr_model} is not yet represented in the dev "
-                    "data creation."
-                )

--- a/backend/main/management/commands/create_dev_dataset_test.py
+++ b/backend/main/management/commands/create_dev_dataset_test.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Type
 from django.apps import apps
 from django.conf import settings
 from django.db.models import Model
@@ -12,12 +13,10 @@ from form.models import (
     StepInfoText,
 )
 
-type ModelType = type[Model]
-
 # Add models here that should be excluded from the completeness check. These
 # are models that are not essential for the dev dataset or are difficult to
 # generate automatically.
-EXCLUDED_MODELS_FOR_COMPLETENESS_CHECK: list[ModelType] = [
+EXCLUDED_MODELS_FOR_COMPLETENESS_CHECK: list[Type[Model]] = [
     StepInfoQuestion,
     StepInfoText,
     QuestionResponse,

--- a/backend/main/management/commands/create_dev_dataset_test.py
+++ b/backend/main/management/commands/create_dev_dataset_test.py
@@ -1,0 +1,53 @@
+import pytest
+from django.apps import apps
+from django.conf import settings
+from django.db.models import Model
+from django.core.management import call_command
+
+from form.models import (
+    QuestionCondition,
+    QuestionResponse,
+    StepCondition,
+    StepInfoQuestion,
+    StepInfoText,
+)
+
+type ModelType = type[Model]
+
+# Add models here that should be excluded from the completeness check. These
+# are models that are not essential for the dev dataset or are difficult to
+# generate automatically.
+EXCLUDED_MODELS_FOR_COMPLETENESS_CHECK: list[ModelType] = [
+    StepInfoQuestion,
+    StepInfoText,
+    QuestionResponse,
+    StepCondition,
+    QuestionCondition,
+]
+
+
+def test_create_dev_data(db):
+    """
+    Tests that the create_dev_data command runs without errors and verifies
+    that test data is generated for all models in LOCAL_APPS.
+    """
+    try:
+        call_command("create_dev_data", "--force", "--silent")
+    except Exception as e:
+        pytest.fail(f"Error occurred while running create_dev_data command: {e}")
+
+    all_mr_models = [
+        mr_model
+        for app in settings.LOCAL_APPS
+        for mr_model in apps.get_app_config(app).get_models()
+    ]
+
+    for MRModel in all_mr_models:
+        if MRModel in EXCLUDED_MODELS_FOR_COMPLETENESS_CHECK:
+            continue
+        instances_exist = MRModel.objects.exists()
+        assert instances_exist is True, (
+            f"Model {MRModel.__name__} has no instances. "
+            f"Please add it to the dev dataset generator or add it to "
+            f"the EXCLUDED_MODELS_FOR_COMPLETENESS_CHECK list."
+        )


### PR DESCRIPTION
The check whether all models are accounted for in `create_dev_data` no longer happens in the command itself, but in an individual test. The same test also checks whether `create_dev_data` completes successfully, so we are notified if one of our PRs threatens to break it.

Instead of adding a model to a list if you _have_ implemented a dev data generator for it, you now have to opt out by adding models for which it is _not_ represented in `create_dev_data`. On all models not present in the list, `objects.exists()` is called to check whether objects actually exist (instead of taking the developer's word for it).