### PR TITLE
Fix Vue-TSC watcher (and codegen) in frontend container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -123,17 +123,27 @@ services:
       - "3000"
     ports:
       - "3000:3000"
-    volumes:
-      # Enable live-reloading of frontend code.
-      - ./frontend:/app
-      # Use container's node_modules.
-      - frontend-node-modules:/app/node_modules
     environment:
       # Allows Nuxt to be accessible from the outside.
       - HOST=0.0.0.0
       - CODEGEN_SCHEMA=http://mr-django:8000/api/graphql
       - NUXT_PUBLIC_API_URL=${BASE_URL}/api
       - NUXT_PUBLIC_SAML_URL=${BASE_URL}/saml
+    develop:
+      watch:
+        - path: ./frontend
+          target: /app
+          action: sync
+          ignore:
+            - node_modules
+            - .nuxt
+            - dist
+        - path: ./frontend/package.json
+          target: /app/package.json
+          action: restart
+        - path: ./frontend/vite.config.js
+          target: /app/vite.config.js
+          action: restart
 
   vue-prod:
     image: mr-vue-prod
@@ -183,7 +193,6 @@ services:
       - public_cert
 
 volumes:
-  frontend-node-modules:
   pgdata:
   bapyca:
   backend_static:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,16 +1,34 @@
-FROM node:22.16.0-alpine
+ARG NODE_VERSION=22.16.0-alpine
+
+FROM node:${NODE_VERSION} AS dev
+
+ENV NODE_ENV=development
 
 # Add git.
 RUN apk add --no-cache git
 
-# Add python because of the i18n-check script
+# Install Python for the i18n-check script.
 RUN apk add python3
 
 # Set the working directory in the container.
 WORKDIR /app
 
-# Source is not copied because it is mounted as a volume
+COPY package.json package-lock.json ./
+
+# Install with mount to cache node_modules.
+RUN --mount=type=cache,target=/root/.npm npm install
+
+COPY . .
+
+# Change ownership of the app directory to the node user.
+# This is necessary for watch mode.
+RUN chown -R node:node /app
+
+USER node
 
 # Nuxt 3 default port is 3000.
 # Does not actually expose the port but documents it.
 EXPOSE 3000
+
+# Run the development server and codegen in parallel.
+CMD ["npm", "run", "dev", "&", "npm", "run", "codegen"]


### PR DESCRIPTION
Fixes #231 

With the kind help of @EdoStorm96 I've recently switched to using the Docker containers for development. (I used to run local dev servers on my machine before.)

I noticed that our current setup picks up code changes correctly but does not run the Vue typechecker (`vue-tsc`). As a result, type errors that are there when the container is started never go away, and new type errors are not picked up until you manually restart the container, which is quite annoying.

(I also seem to have had at least one case in which GraphQL codegen failed to run when I made a change to one of the queries, but I've heard from @EdoStorm96 that codegen does work on his machine, so maybe that was a fluke.)

This PR implements `docker compose watch` using [this guide](https://docs.docker.com/guides/vuejs/develop). By running `docker compose --profile dev up --watch` you start the containers in watch mode. For the `vue-dev` service, this means that code changes are continuously synced (and a rebuild is triggered is dependencies are added). This means we don't need the volumes anymore.

To test, run `docker compose --profile dev up --watch` and:
- Update a template. (This already works on develop.)
- Commit a type error somewhere (e.g. use an unknown function) and verify that the type error pops up in the browser.
- Update a query and verify that the types are regenerated (by codegen).