### PR TITLE
Feature/validate true false questions

### DIFF
--- a/backend/api/graphql/schema.py
+++ b/backend/api/graphql/schema.py
@@ -1,6 +1,5 @@
 from graphene import Schema, ObjectType
 
-from research.types.StudyType import GQLSubmissionStatus
 from form.types.QuestionType import (
     QuestionType,
     BaseQuestionInterface,

--- a/frontend/composables/useProcessForm.test.ts
+++ b/frontend/composables/useProcessForm.test.ts
@@ -480,5 +480,18 @@ describe("useProcessForm", () => {
             expect(positiveValidator(10, null, null)).toBe(true);
             expect(positiveValidator(-5, null, null)).toBe(false);
         });
+
+        it("should validate required True/False questions correctly", () => {
+            const queriedForm = createQueriedForm();
+            const { validationRules } = useProcessForm(queriedForm);
+
+            const trueFalseQuestionRules =
+                validationRules.steps[0].substeps[0].questions[0].value;
+            const requiredValidator =
+                trueFalseQuestionRules.required.$validator;
+
+            expect(requiredValidator(true, null, null)).toBe(true);
+            expect(requiredValidator(false, null, null)).toBe(false);
+        });
     });
 });

--- a/frontend/composables/useProcessForm.ts
+++ b/frontend/composables/useProcessForm.ts
@@ -306,17 +306,16 @@ function addValidationRule(
 
     // General validation rules
     if (question.required) {
-        rules.required = helpers.withMessage(
-            t("This field is required"),
-            required,
-        );
-    }
+        // For TrueFalseQuestions, 'required' means True must be selected.
+        // For other question types, use the built-in `required` validator.
+        const requiredFn =
+            question.__typename === "TrueFalseQuestionType"
+                ? (value: boolean) => value
+                : required;
 
-    // For True/False questions, 'required' means True.
-    if (question.required && question.__typename === "TrueFalseQuestionType") {
         rules.required = helpers.withMessage(
             t("This field is required"),
-            (value: boolean) => value,
+            requiredFn,
         );
     }
 

--- a/frontend/composables/useProcessForm.ts
+++ b/frontend/composables/useProcessForm.ts
@@ -312,6 +312,14 @@ function addValidationRule(
         );
     }
 
+    // For True/False questions, 'required' means True.
+    if (question.required && question.__typename === "TrueFalseQuestionType") {
+        rules.required = helpers.withMessage(
+            t("This field is required"),
+            (value: boolean) => value,
+        );
+    }
+
     // Question-type specific rules. This is an example. Add more as needed.
     switch (question.__typename) {
         case "NumberQuestionType":

--- a/frontend/composables/useProcessForm.ts
+++ b/frontend/composables/useProcessForm.ts
@@ -306,8 +306,10 @@ function addValidationRule(
 
     // General validation rules
     if (question.required) {
-        // For TrueFalseQuestions, 'required' means True must be selected.
-        // For other question types, use the built-in `required` validator.
+        // For TrueFalseQuestions, a value is always present (true or false),
+        // so Vuelidate's generic `required` validator is not sufficient here.
+        // Instead, the user must explicitly choose/confirm `true` for such
+        // questions (e.g. "I have understood the above").
         const requiredFn =
             question.__typename === "TrueFalseQuestionType"
                 ? (value: boolean) => value


### PR DESCRIPTION
TrueFalseQuestions always have a value, so Vuelidate's built-in `required` validator always passes and questions like "I've understood the above" never block submission.

A special addition is made to `useProcessForm()`: required TrueFalseQuestions should have an answer with value `True` to be admitted.