### PR TITLE
fix: update useFormState to immediate: true and watch QueriedFormRef.value

### DIFF
--- a/frontend/composables/useFormState.ts
+++ b/frontend/composables/useFormState.ts
@@ -35,15 +35,15 @@ export function useFormState(queriedFormRef: Ref<QueriedForm>) {
         };
     }
 
-    // Reprocess form input upon refetching.
+    // Reprocess form input upon refetching - never cache, always use current query
     watch(
-        queriedFormRef,
+        () => queriedFormRef.value,
         (newQueriedForm) => {
             const processed = useProcessForm(newQueriedForm);
             formState.value.formWithValues = processed.formWithValues;
             formState.value.validationRules = processed.validationRules;
         },
-        { deep: true },
+        { deep: true, immediate: true },
     );
 
     return {

--- a/frontend/composables/useFormState.ts
+++ b/frontend/composables/useFormState.ts
@@ -35,7 +35,7 @@ export function useFormState(queriedFormRef: Ref<QueriedForm>) {
         };
     }
 
-    // Reprocess form input upon refetching - never cache, always use current query
+    // Keep the cached form state in sync with the latest query result.
     watch(
         () => queriedFormRef.value,
         (newQueriedForm) => {


### PR DESCRIPTION
This fixes the issue with cached forms. The query was working fine still, but the frontend watcher is lazy by default. Changing the watcher settings to immediate: true, and using QueriedFormRef.value as the watch source, ensure the form is always reprocessed, when the query changes.

So now, when we make a new study, we will not be seeing old study's value anymore.

fixes #308 