### PR TITLE
Fix/backend validation handling + other minor issues

### DIFF
--- a/backend/form/mutations/UpdateUserFormSubmission.py
+++ b/backend/form/mutations/UpdateUserFormSubmission.py
@@ -31,7 +31,7 @@ class UpdateUserFormSubmission(Mutation):
         user: User = info.context.user
 
         try:
-            submission = update_submission(
+            submission, errors = update_submission(
                 user,
                 user_form_input,
             )
@@ -41,6 +41,10 @@ class UpdateUserFormSubmission(Mutation):
                 messages=[str(e)],
             )
             return cls(ok=False, errors=[error])
+
+        # If there were validation errors, return them
+        if errors:
+            return cls(ok=False, errors=errors)
 
         study: Study = submission.study  # type: ignore
 

--- a/backend/form/services/create_user_form_revision_test.py
+++ b/backend/form/services/create_user_form_revision_test.py
@@ -30,6 +30,7 @@ class TestCreateRevision:
         """Test updating an answer for revision"""
 
         submission, errors = update_submission(test_user, user_form_input)
+        assert errors == []
         old_response = QuestionResponse.objects.filter(submissions=submission).first()
 
         submission_revision = create_user_form_revision(submission.id)

--- a/backend/form/services/create_user_form_revision_test.py
+++ b/backend/form/services/create_user_form_revision_test.py
@@ -70,6 +70,7 @@ class TestCreateRevision:
         user_form_input["responses"][0]["answer"] = new_ans
 
         updated_revision, errors = update_submission(test_user, user_form_input)
+        assert errors == []
         new_response = QuestionResponse.objects.filter(
             submissions=updated_revision
         ).first()

--- a/backend/form/services/create_user_form_revision_test.py
+++ b/backend/form/services/create_user_form_revision_test.py
@@ -15,7 +15,7 @@ class TestCreateRevision:
         """Test creation of revision of UserFormSubmission"""
 
         # First update the submission to add responses
-        submission = update_submission(test_user, user_form_input)
+        submission, errors = update_submission(test_user, user_form_input)
 
         submission_revision = create_user_form_revision(submission.id)
 
@@ -28,7 +28,7 @@ class TestCreateRevision:
     def test_update_revision_response(self, test_user, submission, user_form_input):
         """Test updating an answer for revision"""
 
-        submission = update_submission(test_user, user_form_input)
+        submission, errors = update_submission(test_user, user_form_input)
         old_response = QuestionResponse.objects.filter(submissions=submission).first()
 
         submission_revision = create_user_form_revision(submission.id)
@@ -41,7 +41,7 @@ class TestCreateRevision:
         # If we update the revision, but the answer remains the same, the old
         # response should remain intact.
 
-        updated_revision = update_submission(test_user, user_form_input)
+        updated_revision, errors = update_submission(test_user, user_form_input)
 
         assert updated_revision == submission_revision
         assert set(updated_revision.responses.all()) == set(
@@ -53,7 +53,7 @@ class TestCreateRevision:
         self, test_user, submission, user_form_input
     ):
 
-        submission = update_submission(test_user, user_form_input)
+        submission, errors = update_submission(test_user, user_form_input)
         old_response = QuestionResponse.objects.filter(submissions=submission).first()
 
         submission_revision = create_user_form_revision(submission.id)
@@ -65,7 +65,7 @@ class TestCreateRevision:
         new_ans = {"value": "new_answer"}
         user_form_input["responses"][0]["answer"] = new_ans
 
-        updated_revision = update_submission(test_user, user_form_input)
+        updated_revision, errors = update_submission(test_user, user_form_input)
         new_response = QuestionResponse.objects.filter(
             submissions=updated_revision
         ).first()

--- a/backend/form/services/create_user_form_revision_test.py
+++ b/backend/form/services/create_user_form_revision_test.py
@@ -16,6 +16,7 @@ class TestCreateRevision:
 
         # First update the submission to add responses
         submission, errors = update_submission(test_user, user_form_input)
+        assert errors == []
 
         submission_revision = create_user_form_revision(submission.id)
 

--- a/backend/form/services/create_user_form_revision_test.py
+++ b/backend/form/services/create_user_form_revision_test.py
@@ -57,6 +57,7 @@ class TestCreateRevision:
     ):
 
         submission, errors = update_submission(test_user, user_form_input)
+        assert errors == []
         old_response = QuestionResponse.objects.filter(submissions=submission).first()
 
         submission_revision = create_user_form_revision(submission.id)

--- a/backend/form/services/create_user_form_revision_test.py
+++ b/backend/form/services/create_user_form_revision_test.py
@@ -44,6 +44,7 @@ class TestCreateRevision:
         # response should remain intact.
 
         updated_revision, errors = update_submission(test_user, user_form_input)
+        assert errors == []
 
         assert updated_revision == submission_revision
         assert set(updated_revision.responses.all()) == set(

--- a/backend/form/services/update_submission.py
+++ b/backend/form/services/update_submission.py
@@ -23,7 +23,9 @@ def _delete_document_if_cleared(old_answer: dict, new_answer: dict) -> None:
             pass
 
 
-def update_submission(user: User, user_form_input: UserFormInput) -> UserFormSubmission:
+def update_submission(
+    user: User, user_form_input: UserFormInput
+) -> tuple[UserFormSubmission, list[ErrorType]]:
     # Usually we can use user_form_input.submission_id or getattr(user_form_input, "submission_id").
     # This breaks the tests, however, where user_form_input is mocked as a dict.
     # That is why we use .get() here, which handles both cases.

--- a/backend/form/services/update_submission.py
+++ b/backend/form/services/update_submission.py
@@ -49,12 +49,11 @@ def update_submission(user: User, user_form_input: UserFormInput) -> UserFormSub
             validate_response(response)
         except Exception as e:
             # if responses cause an error, add an error to the mutation's response
+            question_id = response.get("question_id", "<unknown>")
             errors.append(
                 ErrorType(
                     field="responses",
-                    messages=[
-                        f"the answer: '{response['answer']['value']}' to question {response['question_id']} caused an exception: {e}"
-                    ],
+                    messages=[f"Invalid response for question {question_id}: {e}"],
                 )
             )
             # We don't save responses that do not pass validation

--- a/backend/form/services/update_submission.py
+++ b/backend/form/services/update_submission.py
@@ -44,10 +44,11 @@ def update_submission(user: User, user_form_input: UserFormInput) -> UserFormSub
 
     for response in user_form_input.get("responses", []):  # type: ignore
         response_id = response["id"] if "id" in response else None
-        # Immediately cut off responses that are not valid.
+
         try:
             validate_response(response)
         except Exception as e:
+            # if responses cause an error, add an error to the mutation's response
             errors.append(
                 ErrorType(
                     field="responses",
@@ -56,6 +57,7 @@ def update_submission(user: User, user_form_input: UserFormInput) -> UserFormSub
                     ],
                 )
             )
+            # We don't save responses that do not pass validation
             continue
 
         if response_id:

--- a/backend/form/services/update_submission.py
+++ b/backend/form/services/update_submission.py
@@ -1,4 +1,5 @@
 from main.models import MRPermission, User
+from graphene_django.types import ErrorType
 from form.models.responses import MRDocument
 from form.mutations.utils.inputs import UserFormInput
 from django.utils import timezone
@@ -42,10 +43,24 @@ def update_submission(user: User, user_form_input: UserFormInput) -> UserFormSub
             f"belonging to user {user} does not exist."
         )
 
+    errors: list[ErrorType] = []
+
     for response in user_form_input.get("responses", []):  # type: ignore
         response_id = response["id"] if "id" in response else None
         # Immediately cut off responses that are not valid.
-        validate_response(response)
+        try:
+            validate_response(response)
+        except Exception as e:
+            errors.append(
+                ErrorType(
+                    field="responses",
+                    messages=[
+                        f"the answer: '{response['answer']['value']}' to question {response['question_id']} caused an exception: {e}"
+                    ],
+                )
+            )
+            continue
+
         if response_id:
             # See if the response already exists
             qr = QuestionResponse.objects.get(id=response["id"])
@@ -79,7 +94,7 @@ def update_submission(user: User, user_form_input: UserFormInput) -> UserFormSub
             new_response.submissions.add(current_submission)
             current_submission.updated_at = timezone.now()
     current_submission.save()
-    return current_submission
+    return current_submission, errors
 
 
 def validate_response(response):

--- a/backend/form/services/update_submission.py
+++ b/backend/form/services/update_submission.py
@@ -7,9 +7,6 @@ from form.models import (
     UserFormSubmission,
     QuestionResponse,
     BaseQuestion,
-    TextQuestion,
-    NumberQuestion,
-    DateQuestion,
 )
 
 
@@ -99,25 +96,6 @@ def update_submission(user: User, user_form_input: UserFormInput) -> UserFormSub
 
 def validate_response(response):
     """Backend validation incase malicious responses. Under normal circumstances all validations are already checked in the frontend"""
-    question_id = response["question_id"]
-    answer = response["answer"]
-    value = answer["value"]
-    question = get_question(question_id)
+    question = BaseQuestion.objects.get(id=response["question_id"]).get_subclass()
     # validate will throw an error in case of wrong input.
-    question.validate(value)
-
-
-def get_question(
-    question_id: int,
-) -> BaseQuestion | NumberQuestion | TextQuestion | DateQuestion:
-    """Searches child models of BaseQuestion and returns the appropriate question"""
-    # This answer will always be the same in the current form version.
-    # We might want to consider caching in the future.
-    if TextQuestion.objects.filter(id=question_id).exists():
-        return TextQuestion.objects.get(id=question_id)
-    elif NumberQuestion.objects.filter(id=question_id).exists():
-        return NumberQuestion.objects.get(id=question_id)
-    elif DateQuestion.objects.filter(id=question_id).exists():
-        return DateQuestion.objects.get(id=question_id)
-    else:
-        return BaseQuestion.objects.get(id=question_id)
+    question.validate(response["answer"]["value"])

--- a/backend/form/services/update_submission_test.py
+++ b/backend/form/services/update_submission_test.py
@@ -14,6 +14,7 @@ class TestUpdateSubmission:
         """Test updating an answer"""
 
         submission, errors = update_submission(test_user, user_form_input)
+        assert errors == []
         response = QuestionResponse.objects.filter(submissions=submission).first()
 
         new_ans = {"value": "new_answer"}

--- a/backend/form/services/update_submission_test.py
+++ b/backend/form/services/update_submission_test.py
@@ -13,7 +13,7 @@ class TestUpdateSubmission:
     def test_update_response(self, test_user, user_form_input):
         """Test updating an answer"""
 
-        submission = update_submission(test_user, user_form_input)
+        submission, errors = update_submission(test_user, user_form_input)
         response = QuestionResponse.objects.filter(submissions=submission).first()
 
         new_ans = {"value": "new_answer"}
@@ -25,7 +25,7 @@ class TestUpdateSubmission:
         old_ans = response.answer
         old_response_id = response.id
 
-        submission = update_submission(test_user, user_form_input)
+        submission, errors = update_submission(test_user, user_form_input)
         response = QuestionResponse.objects.filter(submissions=submission).first()
 
         assert submission.responses.count() == 1

--- a/backend/myresearch/settings/generic_settings.py
+++ b/backend/myresearch/settings/generic_settings.py
@@ -126,7 +126,7 @@ LANGUAGES = [
     ("nl", _("Dutch")),
 ]
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Europe/Brussels"
 
 USE_I18N = True
 

--- a/backend/research/models/study.py
+++ b/backend/research/models/study.py
@@ -22,12 +22,14 @@ class StudyManager(BaseMRManager):
     def _deletable_objects(self, user: User):
         queryset = self.filter(is_deleted=False)
 
-        # POs and FETC members can only (soft) delete submitted studies.
+        # POs and FETC members can only (soft) delete submitted studies or
+        # (hard) delete their own never submitted studies
         if user.is_privacy_officer or user.is_fetc_member:
-            return self.with_has_been_submitted_annotation(queryset).filter(
-                has_been_submitted=True
+            return queryset.filter(has_been_submitted=True) | queryset.filter(
+                created_by=user, has_been_submitted=False
             )
-        return queryset.filter(created_by=user)
+        # Normal users can only (hard) delete studies they've created, that have never been submitted
+        return queryset.filter(created_by=user, has_been_submitted=False)
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/backend/research/tests.py
+++ b/backend/research/tests.py
@@ -429,6 +429,7 @@ class TestDeleteStudyMutation:
 
         result = self._execute(normal_user, test_study.pk)
 
+        assert not result.errors
         assert result.data
         assert result.data["deleteStudy"]["ok"] is False
         assert result.data["deleteStudy"]["errors"]

--- a/backend/research/tests.py
+++ b/backend/research/tests.py
@@ -419,8 +419,7 @@ class TestDeleteStudyMutation:
 
     def test_soft_delete_submitted_study(self, normal_user: User, test_study: Study):
         """
-        Owner can soft-delete a study that has been submitted; it remains in
-        the database with is_deleted=True.
+        Owner cannot soft-delete a study that has been submitted.
         """
         StatusChange.objects.create(
             study=test_study,
@@ -430,13 +429,12 @@ class TestDeleteStudyMutation:
 
         result = self._execute(normal_user, test_study.pk)
 
-        assert not result.errors
         assert result.data
-        assert result.data["deleteStudy"]["ok"] is True
-        assert not result.data["deleteStudy"]["errors"]
+        assert result.data["deleteStudy"]["ok"] is False
+        assert result.data["deleteStudy"]["errors"]
 
         test_study.refresh_from_db()
-        assert test_study.is_deleted is True
+        assert test_study.is_deleted is False
 
     def test_delete_another_users_study_returns_error(
         self, normal_user: User, test_po_study: Study

--- a/backend/research/utils/study_actions.py
+++ b/backend/research/utils/study_actions.py
@@ -31,11 +31,11 @@ class StudyActions:
         self.user = user
         self.all_actions = [
             StudyEditAction,
-            StudyDeleteAction,
             StudyViewAction,
             ReturnToDraftAction,
             MarkSeenAction,
             MarkUnseenAction,
+            StudyDeleteAction,
         ]
 
     def get_available_actions(self) -> list[ActionEnum]:

--- a/frontend/components/form/FormWrapper.vue
+++ b/frontend/components/form/FormWrapper.vue
@@ -72,8 +72,13 @@ function submitForm(options = { submit: false }): void {
         }
     }
 
+    const step = selectedStep.value;
+    if (!step) {
+        return;
+    }
+
     const inputData = useFormDataToMutationInput(
-        formData,
+        step,
         props.queriedForm.submissionId,
     );
 

--- a/frontend/composables/useFormDataToMutationInput.ts
+++ b/frontend/composables/useFormDataToMutationInput.ts
@@ -1,35 +1,15 @@
 import type { UserFormInput } from "~/generated/gql/graphql";
-import type {
-    StepWithValues,
-    SubstepWithValues,
-    QuestionWithValue,
-    FormWithValues,
-} from "~/composables/useProcessForm";
+import type { CombinedStepWithValues } from "~/composables/useProcessForm";
 
 /**
- * Recursively collects all questions from a step and its substeps, and puts them in a flat array.
- */
-function getAllQuestions(
-    step: StepWithValues | SubstepWithValues,
-): QuestionWithValue[] {
-    const ownQuestions = step.questions;
-
-    const subStepQuestions =
-        "substeps" in step
-            ? (step.substeps?.flatMap(getAllQuestions) ?? [])
-            : [];
-
-    return [...ownQuestions, ...subStepQuestions];
-}
-
-/**
- * Utility function to transform our form into the expected input for our mutation.
+ * Utility function to transform the responses of a single step (or substep)
+ * into the expected input for our mutation.
  */
 function useFormDataToMutationInput(
-    formData: FormWithValues,
+    step: CombinedStepWithValues,
     submissionId: string,
 ): UserFormInput {
-    const questions = formData.steps.flatMap(getAllQuestions);
+    const questions = step.questions;
 
     return {
         submissionId: submissionId,

--- a/frontend/composables/useFormState.ts
+++ b/frontend/composables/useFormState.ts
@@ -35,15 +35,15 @@ export function useFormState(queriedFormRef: Ref<QueriedForm>) {
         };
     }
 
-    // Reprocess form input upon refetching.
+    // Reprocess form input upon refetching - never cache, always use current query
     watch(
-        queriedFormRef,
+        () => queriedFormRef.value,
         (newQueriedForm) => {
             const processed = useProcessForm(newQueriedForm);
             formState.value.formWithValues = processed.formWithValues;
             formState.value.validationRules = processed.validationRules;
         },
-        { deep: true },
+        { deep: true, immediate: true },
     );
 
     return {


### PR DESCRIPTION
fixes #311 

Backend validation was not working properly. This is fixed now. The backend now just sends an error to the response of the graphql request. When a response does not pass validation, it does not get saved. However all other responses do get saved.

I've also made a pretty major change to how we submit responses (which was actually pretty minor to implement). Instead of submitting the whole form everytime, we now only submit the responses for the current step. This should save a lot of time on the backend as we do not validate the whole form on every update_submission, just the step that has been edited. This was actually only a change to the frontend. The backend was totally ready for this and did not require any changes to implement this, so that is nice.

I've also applied the fixes from #302 here, so I closed that branch, as it was no longer relevant.