### PR TITLE
fix: filter out questions with errors before mutation

### DIFF
--- a/frontend/composables/useFormDataToMutationInput.ts
+++ b/frontend/composables/useFormDataToMutationInput.ts
@@ -13,16 +13,21 @@ function useFormDataToMutationInput(
 
     return {
         submissionId: submissionId,
-        responses: questions.map((question) => ({
-            // FileUploadQuestion answers are already in the correct format.
-            answer:
-                question.__typename === "FileUploadQuestionType"
-                    ? JSON.stringify(question.value ?? { value: "" })
-                    : JSON.stringify({ value: question.value }),
-            id: question.responseId,
-            questionId: question.questionId,
-            repeatIndex: question.repeatIndex,
-        })),
+        responses: questions
+            // Do not send questions with errors to the backend
+            .filter(
+                (question) => !question.errors || question.errors.length === 0,
+            )
+            .map((question) => ({
+                // FileUploadQuestion answers are already in the correct format.
+                answer:
+                    question.__typename === "FileUploadQuestionType"
+                        ? JSON.stringify(question.value ?? { value: "" })
+                        : JSON.stringify({ value: question.value }),
+                id: question.responseId,
+                questionId: question.questionId,
+                repeatIndex: question.repeatIndex,
+            })),
     };
 }
 


### PR DESCRIPTION
One more addendum to #313. @RoordinkFrank pointed out we ideally should also filter out answers that cause errors in the frontend, before sending them to the backend.