### PR TITLE
Align middle study list table data

### DIFF
--- a/frontend/pages/studies/index.vue
+++ b/frontend/pages/studies/index.vue
@@ -192,7 +192,7 @@ const filters = computed<UUListTypes.FilterDefinition[]>(() => {
                 </thead>
                 <tbody>
                     <tr v-for="row in data" :key="row.id">
-                        <td>
+                        <td class="align-middle">
                             {{ row.reference }}
                         </td>
                         <td class="align-middle">
@@ -205,17 +205,17 @@ const filters = computed<UUListTypes.FilterDefinition[]>(() => {
                                 {{ row.title }}
                             </NuxtLink>
                         </td>
-                        <td>
+                        <td class="align-middle">
                             <StatusBadge :status="row.status" />
                         </td>
-                        <td
+                        <td class="align-middle"
                             v-if="
                                 currentUserStore.currentUser?.isPrivacyOfficer
                             "
                         >
                             <IsSeenBadge :isSeen="row.isSeen" />
                         </td>
-                        <td>
+                        <td class="align-middle">
                             {{ row.createdBy.fullName }}
                         </td>
                     </tr>


### PR DESCRIPTION
Closes #310 
All table data columns in the study list are now aligned to the middle (vertical alignment)