### PR TITLE
fix: restrict the use of _delete_document_if_cleared

### DIFF
--- a/backend/form/services/update_submission.py
+++ b/backend/form/services/update_submission.py
@@ -80,7 +80,7 @@ def update_submission(
                     )
                     new_response.submissions.add(current_submission)
                 else:
-                    if not response["answer"].get("value") and isinstance(
+                    if response["answer"]["value"] == "" and isinstance(
                         qr.question.get_subclass(), FileUploadQuestion
                     ):
                         _delete_document_if_cleared(qr.answer, response["answer"])

--- a/backend/form/services/update_submission.py
+++ b/backend/form/services/update_submission.py
@@ -1,3 +1,4 @@
+from form.models.questions import FileUploadQuestion
 from main.models import MRPermission, User
 from graphene_django.types import ErrorType
 from form.models.responses import MRDocument
@@ -79,8 +80,11 @@ def update_submission(
                     )
                     new_response.submissions.add(current_submission)
                 else:
+                    if response["answer"]["value"] == "" and isinstance(
+                        qr.question.get_subclass(), FileUploadQuestion
+                    ):
+                        _delete_document_if_cleared(qr.answer, response["answer"])
                     # If this is not a revision, just update the answer
-                    _delete_document_if_cleared(qr.answer, response["answer"])
                     qr.answer = response["answer"]
                     qr.save()
 

--- a/backend/form/services/update_submission.py
+++ b/backend/form/services/update_submission.py
@@ -80,7 +80,7 @@ def update_submission(
                     )
                     new_response.submissions.add(current_submission)
                 else:
-                    if response["answer"]["value"] == "" and isinstance(
+                    if not response["answer"].get("value") and isinstance(
                         qr.question.get_subclass(), FileUploadQuestion
                     ):
                         _delete_document_if_cleared(qr.answer, response["answer"])


### PR DESCRIPTION
fixes #331

this was caused by _delete_document_if_cleared. It now only runs when the new answer is actually an empty string and the question is a FileUploadQuestion.