### PR TITLE
Add volumes for node_modules and .nuxt

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -131,6 +131,8 @@ services:
       - NUXT_PUBLIC_SAML_URL=${BASE_URL}/saml
     volumes:
       - ./frontend/generated:/app/generated
+      - ./frontend/.nuxt:/app/.nuxt
+      - ./frontend/node_modules:/app/node_modules
     develop:
       watch:
         - path: ./frontend


### PR DESCRIPTION
This fixes type errors that @evania ran into upon starting MR in Docker.

For proper type checking, VS Code uses `.nuxt` (containing generated types for the Vue/Nuxt components + pages) and `node_modules` (for types related to external dependencies. These are created in the `vue-dev` container, but these are not automatically available on the host machine, so VS Code cannot access them and throws type errors.

(The reason that nobody else ran into this problem before is that we probably all have run `npm install` and `npm run dev` on our host machine before, which generates `node_modules` and `.nuxt`.)

This PR adds two Docker volumes so these directories are now shared between the host and the container. 

To test:
- delete your local `node_modules` and `.nuxt` directories;
- start the `vue-dev` container on `develop`: watch type errors appear;
- switch to this branch
- delete the `vue-dev` container, rebuild it with `docker compose build` and restart it in watch mode: `docker compose --profile dev up --watch`
- The type errors should be gone now. (Maybe you have to restart TS or ESLint in your IDE.)