### PR TITLE
Add missing IDs to study status query

### DIFF
--- a/frontend/components/frontpage/RecentActivity.vue
+++ b/frontend/components/frontpage/RecentActivity.vue
@@ -2,6 +2,7 @@
 import { Scale, Pencil } from "lucide-vue-next";
 
 type Status = "DRAFT" | "SUBMITTED_TO_SUPERVISOR";
+
 type Proposal = {
     refNumber: number; // refNumber doesn't show the _, waiting for backend to decide what it should be.
     title: string;
@@ -10,6 +11,7 @@ type Proposal = {
     dateSubmitted: string;
     lastEdited: string;
 };
+
 type Intake = {
     refNumber: number;
     intakeBody: string;
@@ -22,11 +24,11 @@ type RecentActivity = Proposal | Intake;
 const isProposal = (
     recentActivity: RecentActivity,
 ): recentActivity is Proposal => {
-    return recentActivity.hasOwnProperty("status");
+    return "status" in recentActivity;
 };
 
 const isIntake = (recentActivity: RecentActivity): recentActivity is Intake => {
-    return recentActivity.hasOwnProperty("intakeBody");
+    return "intakeBody" in recentActivity;
 };
 </script>
 
@@ -36,6 +38,7 @@ const isIntake = (recentActivity: RecentActivity): recentActivity is Intake => {
     </h2>
     <div
         v-for="activity in recentActivity"
+        :key="activity.refNumber"
         class="card mb-2 text-bg-light mw-100"
     >
         <div class="card-body mw-100">

--- a/frontend/components/studyDetail/StudyProgressBar.vue
+++ b/frontend/components/studyDetail/StudyProgressBar.vue
@@ -3,7 +3,6 @@ import { useQuery } from "@vue/apollo-composable";
 import { graphql } from "~/generated/gql";
 import { useI18n } from "vue-i18n";
 import { useLocalDateTime } from "~/composables/useLocalisation";
-import { useTranslatedStatus } from "~/composables/useTranslatedStatus";
 import { SubmissionStatus } from "~/generated/gql/graphql";
 import Loading from "~/components/shared/Loading.vue";
 
@@ -14,7 +13,9 @@ const props = defineProps<{
 const GET_STUDY_STATUSES = graphql(`
     query GetStudyStatuses($id: ID!) {
         study(id: $id, mrPermission: "View") {
+            id
             statuses {
+                id
                 status
                 createdAt
             }

--- a/frontend/pages/studies/index.vue
+++ b/frontend/pages/studies/index.vue
@@ -208,12 +208,13 @@ const filters = computed<UUListTypes.FilterDefinition[]>(() => {
                         <td class="align-middle">
                             <StatusBadge :status="row.status" />
                         </td>
-                        <td class="align-middle"
+                        <td
                             v-if="
                                 currentUserStore.currentUser?.isPrivacyOfficer
                             "
+                            class="align-middle"
                         >
-                            <IsSeenBadge :isSeen="row.isSeen" />
+                            <IsSeenBadge :is-seen="row.isSeen" />
                         </td>
                         <td class="align-middle">
                             {{ row.createdBy.fullName }}


### PR DESCRIPTION
A simple, small fix for this warning (harmless, but annoying):

<img width="564" height="336" alt="image" src="https://github.com/user-attachments/assets/83f77ee6-37b3-4532-bf90-81b0eab7a21f" />

(Also includes a few unrelated stylistic improvements.)